### PR TITLE
RSPEC-2860 : Deprecate rule AvoidStarImportCheck

### DIFF
--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck.html
@@ -1,1 +1,5 @@
 Check that finds import statements that use the * notation.
+
+<p>
+This rule is deprecated, use {rule:squid:S2208} instead.
+</p>


### PR DESCRIPTION
See [RSPEC-2208](http://jira.sonarsource.com/browse/RSPEC-2208) and [PR](https://github.com/SonarSource/sonar-java/pull/263) available in [sonar-java](https://github.com/SonarSource/sonar-java) v3.4 => checkstyle rule could be deprecated.