### PR TITLE
RSPEC-2974 : Deprecate rule FinalClassCheck

### DIFF
--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck.html
@@ -1,1 +1,5 @@
 Checks that class which has only private constructors is declared as final.
+
+<p>
+This rule is deprecated, use {rule:squid:S2974} instead.
+</p>


### PR DESCRIPTION
See [RSPEC-2974](http://jira.sonarsource.com/browse/RSPEC-2974) and [PR](https://github.com/SonarSource/sonar-java/pull/272) available in [sonar-java](https://github.com/SonarSource/sonar-java) v3.4 => checkstyle rule could be deprecated.