### PR TITLE
RSPEC-3008 : Deprecate rule StaticVariableNameCheck

### DIFF
--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck.html
@@ -1,1 +1,5 @@
 Checks that static, non-final fields conform to the specified format
+
+<p>
+This rule is deprecated, use {rule:squid:S3008} instead.
+</p>


### PR DESCRIPTION
See [RSPEC-3008](http://jira.sonarsource.com/browse/RSPEC-3008) and [PR](https://github.com/SonarSource/sonar-java/pull/277) => checkstyle rule could perhaps be deprecated in the future.