### PR TITLE
RSPEC-1659 : Deprecate rule MultipleVariableDeclarationsCheck

### DIFF
--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck.html
@@ -1,1 +1,5 @@
 Checks that each variable declaration is in its own statement and on its own line.
+
+<p>
+This rule is deprecated, use {rule:squid:S1659} instead.
+</p>


### PR DESCRIPTION
See [RSPEC-1659](http://jira.sonarsource.com/browse/RSPEC-1659) and [PR](https://github.com/SonarSource/sonar-java/pull/281) => checkstyle rule could perhaps be deprecated in the future.