### PR TITLE
RSPEC-3052 : Deprecate rule ExplicitInitializationCheck

### DIFF
--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck.html
@@ -1,1 +1,5 @@
-Checks if any class or object member explicitly initialized to default for its type value (null for object references, zero for numeric types and char and false for boolean.
+Checks if any class or object member explicitly initialized to default for its type value (null for object references, zero for numeric types and char and false for boolean).
+
+<p>
+This rule is deprecated, use {rule:squid:S3052} instead.
+</p>


### PR DESCRIPTION
See [RSPEC-3052](http://jira.sonarsource.com/browse/RSPEC-3052) and [PR](https://github.com/SonarSource/sonar-java/pull/297) => checkstyle rule could perhaps be deprecated in the future.