### PR TITLE
Fix rule definitions for ExecutableStatementCount and JavadocVariable

### DIFF
--- a/sonar-checkstyle-plugin/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
+++ b/sonar-checkstyle-plugin/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
@@ -455,7 +455,7 @@
       <defaultValue>30</defaultValue>
     </param>
     <param key="tokens" type="s[CTOR_DEF,METHOD_DEF,INSTANCE_INIT,STATIC_INIT]">
-      <defaultValue>CTOR_DEF, METHOD_DEF, INSTANCE_INIT, STATIC_INIT</defaultValue>
+      <defaultValue>CTOR_DEF,METHOD_DEF,INSTANCE_INIT,STATIC_INIT</defaultValue>
     </param>
   </rule>
 
@@ -641,7 +641,7 @@
     <param key="format" type="REGULAR_EXPRESSION">
       <defaultValue>^(.*[\\.])?Abstract.*$</defaultValue>
     </param>
-    <!-- 
+    <!--
       Should be s[LITERAL_PUBLIC,LITERAL_PROTECTED,LITERAL_PRIVATE,ABSTRACT,LITERAL_STATIC,FINAL,LITERAL_TRANSIENT,LITERAL_VOLATILE,LITERAL_SYNCHRONIZED,LITERAL_NATIVE,STRICTFP,ANNOTATION,LITERAL_DEFAULT]
       but Checkstyle 6.4 splits the string with ","
     -->
@@ -1791,7 +1791,7 @@
         <defaultValue>true</defaultValue>
     </param>
   </rule>
-  
+
   <rule key="com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck">
     <priority>MAJOR</priority>
     <configKey><![CDATA[Checker/TreeWalker/SummaryJavadocCheck]]></configKey>
@@ -1800,7 +1800,7 @@
     <param key="period" type="STRING">
     </param>
   </rule>
-  
+
   <rule key="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyCatchBlockCheck">
     <priority>MAJOR</priority>
     <configKey><![CDATA[Checker/TreeWalker/EmptyCatchBlockCheck]]></configKey>
@@ -1822,7 +1822,7 @@
     </param>
     <status>DEPRECATED</status>
   </rule>
-  
+
   <rule key="com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck">
     <priority>MINOR</priority>
     <name><![CDATA[Comments Indentation]]></name>

--- a/sonar-checkstyle-plugin/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
+++ b/sonar-checkstyle-plugin/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
@@ -842,8 +842,8 @@
     </param>
     <param key="ignoreNamePattern" type="STRING">
     </param>
-    <param key="tokens" type="s[ENUM_CONSTANT_DEF]">
-      <defaultValue>ENUM_CONSTANT_DEF</defaultValue>
+    <param key="tokens" type="s[VARIABLE_DEF,ENUM_CONSTANT_DEF]">
+      <defaultValue>VARIABLE_DEF,ENUM_CONSTANT_DEF</defaultValue>
     </param>
     <status>DEPRECATED</status>
   </rule>


### PR DESCRIPTION
This PR contains two fixes to the rules.xml:
1. The token list in _ExecutableStatementCount_ contained spaces, which led to the rule being broken. It cannot be added to a quality profile at the moment. I removed the spaces.
2. In _JavadocVariable_, the token list is incomplete (`VARIABLE_DEF` is actually an allowed token). This is due to a bug in the Checkstyle documentation. The Checkstyle code accepts `VARIABLE_DEF`, though, so we should be able to set it as well.

Hope this helps!
